### PR TITLE
Add web-based games

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# self_ai
+# Web Games Collection
+
+This repository contains simple web implementations of five classic games:
+
+- **Tetris**
+- **Snake**
+- **Minesweeper**
+- **Poker Solitaire**
+- **Flappy Bird**
+
+Each game lives inside the `games/` directory with its own HTML and JavaScript files.
+
+## Running the Games
+
+Open the corresponding `index.html` file for a game in your web browser. No additional dependencies are required.
+
+```
+./games/tetris/index.html
+./games/snake/index.html
+./games/minesweeper/index.html
+./games/poker-solitaire/index.html
+./games/flappy-bird/index.html
+```
+
+Simply load the file and play!

--- a/games/flappy-bird/flappy.js
+++ b/games/flappy-bird/flappy.js
@@ -1,0 +1,83 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+let frames = 0;
+const gravity = 0.25;
+const jump = 4.6;
+
+const bird = {
+  x:50,
+  y:150,
+  w:34,
+  h:24,
+  frame:0,
+  velocity:0,
+  draw() {
+    ctx.fillStyle = 'yellow';
+    ctx.fillRect(this.x, this.y, this.w, this.h);
+  },
+  update() {
+    this.velocity += gravity;
+    this.y += this.velocity;
+    if (this.y + this.h >= canvas.height) {
+      this.y = canvas.height - this.h;
+      this.velocity = 0;
+    }
+  },
+  flap() {
+    this.velocity = -jump;
+  }
+};
+
+const pipes = {
+  list: [],
+  width: 52,
+  height: 320,
+  gap: 100,
+  reset() { this.list = []; },
+  draw() {
+    ctx.fillStyle = '#0f0';
+    this.list.forEach(p => {
+      ctx.fillRect(p.x, 0, this.width, p.y);
+      ctx.fillRect(p.x, p.y + this.gap, this.width, canvas.height - p.y - this.gap);
+    });
+  },
+  update() {
+    if (frames % 100 === 0) {
+      this.list.push({x:canvas.width, y:Math.floor(Math.random()* (canvas.height- this.gap))});
+    }
+    this.list.forEach(p => p.x -= 2);
+    if (this.list.length && this.list[0].x + this.width < 0) this.list.shift();
+    this.list.forEach(p => {
+      if (bird.x + bird.w > p.x && bird.x < p.x + this.width &&
+          (bird.y < p.y || bird.y + bird.h > p.y + this.gap)) {
+        reset();
+      }
+    });
+  }
+};
+
+function reset() {
+  bird.y = 150;
+  bird.velocity = 0;
+  pipes.reset();
+}
+
+document.addEventListener('keydown', e => {
+  if (e.code === 'Space') bird.flap();
+});
+
+function loop() {
+  frames++;
+  ctx.fillStyle = '#70c5ce';
+  ctx.fillRect(0,0,canvas.width,canvas.height);
+
+  pipes.update();
+  pipes.draw();
+
+  bird.update();
+  bird.draw();
+
+  requestAnimationFrame(loop);
+}
+
+loop();

--- a/games/flappy-bird/index.html
+++ b/games/flappy-bird/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Flappy Bird</title>
+<style>
+body{margin:0;text-align:center;background:#70c5ce;font-family:sans-serif;}
+canvas{background:#70c5ce;display:block;margin:0 auto;}
+</style>
+</head>
+<body>
+<h1>Flappy Bird</h1>
+<canvas id="game" width="400" height="512"></canvas>
+<p>Press space to fly.</p>
+<script src="flappy.js"></script>
+</body>
+</html>

--- a/games/minesweeper/index.html
+++ b/games/minesweeper/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Minesweeper</title>
+<style>
+body{margin:0;text-align:center;background:#222;color:#fff;font-family:sans-serif;}
+#board{display:inline-block;margin-top:20px;}
+.cell{width:30px;height:30px;border:1px solid #555;display:inline-block;line-height:30px;font-weight:bold;cursor:pointer;background:#777;color:#fff;user-select:none;}
+.revealed{background:#ccc;color:#000;}
+</style>
+</head>
+<body>
+<h1>Minesweeper</h1>
+<div id="board"></div>
+<p>Left click to reveal, right click to flag.</p>
+<script src="minesweeper.js"></script>
+</body>
+</html>

--- a/games/minesweeper/minesweeper.js
+++ b/games/minesweeper/minesweeper.js
@@ -1,0 +1,89 @@
+const boardEl = document.getElementById('board');
+const size = 9;
+const mineCount = 10;
+let board = [];
+
+function init() {
+  board = [];
+  boardEl.innerHTML = '';
+  for (let y=0; y<size; y++) {
+    const row = [];
+    for (let x=0; x<size; x++) {
+      const cell = {mine:false,revealed:false,flag:false,count:0,x,y};
+      row.push(cell);
+      const div = document.createElement('div');
+      div.className = 'cell';
+      div.addEventListener('click', () => reveal(cell));
+      div.addEventListener('contextmenu', e => {e.preventDefault(); toggleFlag(cell);});
+      cell.el = div;
+      boardEl.appendChild(div);
+    }
+    board.push(row);
+    const br = document.createElement('br');
+    boardEl.appendChild(br);
+  }
+  placeMines();
+  countNeighbors();
+}
+
+function placeMines() {
+  let placed = 0;
+  while (placed < mineCount) {
+    const x = Math.floor(Math.random()*size);
+    const y = Math.floor(Math.random()*size);
+    const cell = board[y][x];
+    if (!cell.mine) { cell.mine = true; placed++; }
+  }
+}
+
+function countNeighbors() {
+  for (let y=0;y<size;y++) {
+    for (let x=0;x<size;x++) {
+      const cell = board[y][x];
+      if (cell.mine) continue;
+      let count = 0;
+      for (let yy=-1;yy<=1;yy++) {
+        for (let xx=-1;xx<=1;xx++) {
+          if (yy===0&&xx===0) continue;
+          const n = board[y+yy] && board[y+yy][x+xx];
+          if (n && n.mine) count++;
+        }
+      }
+      cell.count = count;
+    }
+  }
+}
+
+function reveal(cell) {
+  if (cell.revealed || cell.flag) return;
+  cell.revealed = true;
+  cell.el.classList.add('revealed');
+  if (cell.mine) {
+    cell.el.textContent = 'X';
+    alert('Game Over');
+    init();
+    return;
+  }
+  if (cell.count) {
+    cell.el.textContent = cell.count;
+  } else {
+    flood(cell);
+  }
+}
+
+function flood(cell) {
+  for (let yy=-1;yy<=1;yy++) {
+    for (let xx=-1;xx<=1;xx++) {
+      const n = board[cell.y+yy] && board[cell.y+yy][cell.x+xx];
+      if (n && !n.revealed && !n.mine) reveal(n);
+    }
+  }
+}
+
+function toggleFlag(cell) {
+  if (cell.revealed) return;
+  cell.flag = !cell.flag;
+  cell.el.textContent = cell.flag ? 'F' : '';
+}
+
+init();

--- a/games/poker-solitaire/index.html
+++ b/games/poker-solitaire/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Poker Solitaire</title>
+<style>
+body{margin:0;text-align:center;background:#222;color:#fff;font-family:sans-serif;}
+#grid{display:inline-grid;grid-template-columns:repeat(5,80px);grid-gap:5px;margin-top:20px;}
+.card{width:80px;height:120px;background:#0b6623;border-radius:6px;display:flex;align-items:center;justify-content:center;font-size:24px;color:#fff;cursor:pointer;}
+.revealed{background:#fff;color:#000;}
+</style>
+</head>
+<body>
+<h1>Poker Solitaire</h1>
+<div id="grid"></div>
+<p>Click to place cards. Game ends after 25 cards.</p>
+<script src="poker.js"></script>
+</body>
+</html>

--- a/games/poker-solitaire/poker.js
+++ b/games/poker-solitaire/poker.js
@@ -1,0 +1,41 @@
+const grid = document.getElementById('grid');
+const suits = ['♠','♥','♦','♣'];
+const ranks = ['A','2','3','4','5','6','7','8','9','10','J','Q','K'];
+let deck = [];
+let placed = 0;
+
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
+function init() {
+  deck = [];
+  for (const s of suits) {
+    for (const r of ranks) {
+      deck.push(`${r}${s}`);
+    }
+  }
+  shuffle(deck);
+  grid.innerHTML = '';
+  placed = 0;
+  for (let i=0;i<25;i++) {
+    const div = document.createElement('div');
+    div.className = 'card';
+    div.addEventListener('click', () => place(div));
+    grid.appendChild(div);
+  }
+}
+
+function place(div) {
+  if (div.textContent || placed >= 25) return;
+  const card = deck.pop();
+  div.textContent = card;
+  div.classList.add('revealed');
+  placed++;
+  if (placed === 25) alert('All cards placed!');
+}
+
+init();

--- a/games/snake/index.html
+++ b/games/snake/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Snake</title>
+<style>
+body{margin:0;text-align:center;background:#222;color:#fff;font-family:sans-serif;}
+canvas{background:#000;margin:20px auto;display:block;}
+</style>
+</head>
+<body>
+<h1>Snake Game</h1>
+<canvas id="game" width="400" height="400"></canvas>
+<p>Use arrow keys to move.</p>
+<script src="snake.js"></script>
+</body>
+</html>

--- a/games/snake/snake.js
+++ b/games/snake/snake.js
@@ -1,0 +1,66 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const grid = 20;
+let count = 0;
+let snake = {x:160, y:160, dx:grid, dy:0, cells:[], max:4};
+let apple = {x:320, y:320};
+
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min)) + min;
+}
+
+document.addEventListener('keydown', evt => {
+  if (evt.key === 'ArrowLeft' && snake.dx === 0) {
+    snake.dx = -grid; snake.dy = 0;
+  } else if (evt.key === 'ArrowUp' && snake.dy === 0) {
+    snake.dy = -grid; snake.dx = 0;
+  } else if (evt.key === 'ArrowRight' && snake.dx === 0) {
+    snake.dx = grid; snake.dy = 0;
+  } else if (evt.key === 'ArrowDown' && snake.dy === 0) {
+    snake.dy = grid; snake.dx = 0;
+  }
+});
+
+function loop() {
+  requestAnimationFrame(loop);
+  if (++count < 4) return;
+  count = 0;
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+
+  snake.x += snake.dx;
+  snake.y += snake.dy;
+
+  if (snake.x < 0) snake.x = canvas.width - grid;
+  else if (snake.x >= canvas.width) snake.x = 0;
+  if (snake.y < 0) snake.y = canvas.height - grid;
+  else if (snake.y >= canvas.height) snake.y = 0;
+
+  snake.cells.unshift({x: snake.x, y: snake.y});
+  if (snake.cells.length > snake.max) {
+    snake.cells.pop();
+  }
+
+  ctx.fillStyle = 'red';
+  ctx.fillRect(apple.x, apple.y, grid-1, grid-1);
+
+  ctx.fillStyle = 'lime';
+  snake.cells.forEach((cell, index) => {
+    ctx.fillRect(cell.x, cell.y, grid-1, grid-1);
+    if (cell.x === apple.x && cell.y === apple.y) {
+      snake.max++;
+      apple.x = getRandomInt(0, 20) * grid;
+      apple.y = getRandomInt(0, 20) * grid;
+    }
+    for (let i = index + 1; i < snake.cells.length; i++) {
+      if (cell.x === snake.cells[i].x && cell.y === snake.cells[i].y) {
+        snake.x = 160; snake.y = 160;
+        snake.cells = []; snake.max = 4;
+        snake.dx = grid; snake.dy = 0;
+        apple.x = getRandomInt(0, 20) * grid;
+        apple.y = getRandomInt(0, 20) * grid;
+      }
+    }
+  });
+}
+
+requestAnimationFrame(loop);

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Tetris</title>
+<style>
+body{margin:0;text-align:center;background:#222;color:#fff;font-family:sans-serif;}
+canvas{background:#000;margin:20px auto;display:block;}
+</style>
+</head>
+<body>
+<h1>Tetris</h1>
+<canvas id="game" width="240" height="400"></canvas>
+<p>Use arrow keys to move, rotate with up arrow.</p>
+<script src="tetris.js"></script>
+</body>
+</html>

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -1,0 +1,231 @@
+const canvas = document.getElementById('game');
+const context = canvas.getContext('2d');
+context.scale(20, 20);
+
+const arena = createMatrix(12, 20);
+const player = {
+  pos: {x: 0, y: 0},
+  matrix: null,
+  score: 0
+};
+
+function createMatrix(w, h) {
+  const matrix = [];
+  while (h--) {
+    matrix.push(new Array(w).fill(0));
+  }
+  return matrix;
+}
+
+function createPiece(type) {
+  if (type === 'T') {
+    return [
+      [0, 0, 0],
+      [1, 1, 1],
+      [0, 1, 0],
+    ];
+  } else if (type === 'O') {
+    return [
+      [2, 2],
+      [2, 2],
+    ];
+  } else if (type === 'L') {
+    return [
+      [0, 3, 0],
+      [0, 3, 0],
+      [0, 3, 3],
+    ];
+  } else if (type === 'J') {
+    return [
+      [0, 4, 0],
+      [0, 4, 0],
+      [4, 4, 0],
+    ];
+  } else if (type === 'I') {
+    return [
+      [0, 5, 0, 0],
+      [0, 5, 0, 0],
+      [0, 5, 0, 0],
+      [0, 5, 0, 0],
+    ];
+  } else if (type === 'S') {
+    return [
+      [0, 6, 6],
+      [6, 6, 0],
+      [0, 0, 0],
+    ];
+  } else if (type === 'Z') {
+    return [
+      [7, 7, 0],
+      [0, 7, 7],
+      [0, 0, 0],
+    ];
+  }
+}
+
+function collide(arena, player) {
+  const m = player.matrix;
+  const o = player.pos;
+  for (let y = 0; y < m.length; ++y) {
+    for (let x = 0; x < m[y].length; ++x) {
+      if (m[y][x] !== 0 &&
+          (arena[y + o.y] &&
+           arena[y + o.y][x + o.x]) !== 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function merge(arena, player) {
+  player.matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (value !== 0) {
+        arena[y + player.pos.y][x + player.pos.x] = value;
+      }
+    });
+  });
+}
+
+function playerDrop() {
+  player.pos.y++;
+  if (collide(arena, player)) {
+    player.pos.y--;
+    merge(arena, player);
+    playerReset();
+    arenaSweep();
+  }
+  dropCounter = 0;
+}
+
+function playerMove(dir) {
+  player.pos.x += dir;
+  if (collide(arena, player)) {
+    player.pos.x -= dir;
+  }
+}
+
+function playerReset() {
+  const pieces = 'ILJOTSZ';
+  player.matrix = createPiece(pieces[pieces.length * Math.random() | 0]);
+  player.pos.y = 0;
+  player.pos.x = (arena[0].length / 2 | 0) -
+                 (player.matrix[0].length / 2 | 0);
+  if (collide(arena, player)) {
+    arena.forEach(row => row.fill(0));
+    player.score = 0;
+    updateScore();
+  }
+}
+
+function rotate(matrix, dir) {
+  for (let y = 0; y < matrix.length; ++y) {
+    for (let x = 0; x < y; ++x) {
+      [matrix[x][y], matrix[y][x]] = [matrix[y][x], matrix[x][y]];
+    }
+  }
+  if (dir > 0) {
+    matrix.forEach(row => row.reverse());
+  } else {
+    matrix.reverse();
+  }
+}
+
+function playerRotate(dir) {
+  const pos = player.pos.x;
+  let offset = 1;
+  rotate(player.matrix, dir);
+  while (collide(arena, player)) {
+    player.pos.x += offset;
+    offset = -(offset + (offset > 0 ? 1 : -1));
+    if (offset > player.matrix[0].length) {
+      rotate(player.matrix, -dir);
+      player.pos.x = pos;
+      return;
+    }
+  }
+}
+
+function arenaSweep() {
+  outer: for (let y = arena.length - 1; y > 0; --y) {
+    for (let x = 0; x < arena[y].length; ++x) {
+      if (arena[y][x] === 0) {
+        continue outer;
+      }
+    }
+    const row = arena.splice(y, 1)[0].fill(0);
+    arena.unshift(row);
+    ++y;
+    player.score += 10;
+  }
+  updateScore();
+}
+
+function drawMatrix(matrix, offset) {
+  matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (value !== 0) {
+        context.fillStyle = colors[value];
+        context.fillRect(x + offset.x,
+                         y + offset.y,
+                         1, 1);
+      }
+    });
+  });
+}
+
+function draw() {
+  context.fillStyle = '#000';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  drawMatrix(arena, {x:0, y:0});
+  drawMatrix(player.matrix, player.pos);
+}
+
+let dropCounter = 0;
+let dropInterval = 1000;
+let lastTime = 0;
+function update(time = 0) {
+  const deltaTime = time - lastTime;
+  lastTime = time;
+
+  dropCounter += deltaTime;
+  if (dropCounter > dropInterval) {
+    playerDrop();
+  }
+
+  draw();
+  requestAnimationFrame(update);
+}
+
+function updateScore() {
+  document.title = `Tetris - ${player.score}`;
+}
+
+const colors = [
+  null,
+  '#FF0D72',
+  '#0DC2FF',
+  '#0DFF72',
+  '#F538FF',
+  '#FF8E0D',
+  '#FFE138',
+  '#3877FF',
+];
+
+document.addEventListener('keydown', event => {
+  if (event.key === 'ArrowLeft') {
+    playerMove(-1);
+  } else if (event.key === 'ArrowRight') {
+    playerMove(1);
+  } else if (event.key === 'ArrowDown') {
+    playerDrop();
+  } else if (event.key === 'ArrowUp') {
+    playerRotate(1);
+  }
+});
+
+playerReset();
+updateScore();
+update();


### PR DESCRIPTION
## Summary
- add Tetris, Snake, Minesweeper, Poker Solitaire, and Flappy Bird games
- update README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a5e1f04648331a939b5333cc38d62