### PR TITLE
Add simple 3D Pong game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Web Games Collection
 
-This repository contains simple web implementations of five classic games:
+This repository contains simple web implementations of six classic games:
 
 - **Tetris**
 - **Snake**
 - **Minesweeper**
 - **Poker Solitaire**
 - **Flappy Bird**
+- **3D Pong**
 
 Each game lives inside the `games/` directory with its own HTML and JavaScript files. A simple landing page is provided at the repository root to help you choose a game quickly.
 
@@ -26,6 +27,7 @@ From there you can select a game to play. If you prefer, you can also open the i
 ./games/minesweeper/index.html
 ./games/poker-solitaire/index.html
 ./games/flappy-bird/index.html
+./games/3d-pong/index.html
 ```
 
 Simply load the file and play!

--- a/games/3d-pong/index.html
+++ b/games/3d-pong/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>3D Pong</title>
+<style>
+body{margin:0;text-align:center;background:#111;color:#fff;font-family:sans-serif;overflow:hidden;}
+#score{position:absolute;top:10px;left:0;right:0;display:flex;justify-content:center;font-size:24px;}
+canvas{display:block;margin:0 auto;}
+</style>
+</head>
+<body>
+<h1>3D Pong</h1>
+<div id="score">0 : 0</div>
+<script src="https://unpkg.com/three@0.159.0/build/three.min.js"></script>
+<script src="pong.js"></script>
+</body>
+</html>

--- a/games/3d-pong/pong.js
+++ b/games/3d-pong/pong.js
@@ -1,0 +1,66 @@
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({antialias: true});
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const light = new THREE.PointLight(0xffffff, 1, 0);
+light.position.set(0, 50, 50);
+scene.add(light);
+
+const paddleGeo = new THREE.BoxGeometry(1, 4, 1);
+const paddleMat = new THREE.MeshPhongMaterial({color: 0x00ff00});
+const paddleLeft = new THREE.Mesh(paddleGeo, paddleMat);
+const paddleRight = new THREE.Mesh(paddleGeo, paddleMat);
+paddleLeft.position.x = -10;
+paddleRight.position.x = 10;
+scene.add(paddleLeft);
+scene.add(paddleRight);
+
+const ballGeo = new THREE.SphereGeometry(0.5, 16, 16);
+const ballMat = new THREE.MeshPhongMaterial({color: 0xff0000});
+const ball = new THREE.Mesh(ballGeo, ballMat);
+scene.add(ball);
+
+const wallGeo = new THREE.BoxGeometry(22, 12, 1);
+const wallMat = new THREE.MeshBasicMaterial({color: 0x222222, wireframe: true});
+const wall = new THREE.Mesh(wallGeo, wallMat);
+wall.position.z = -1;
+scene.add(wall);
+
+camera.position.z = 20;
+
+let ballDirX = 0.25;
+let ballDirY = 0.15;
+let leftScore = 0;
+let rightScore = 0;
+
+function updateScore() {
+  document.getElementById('score').textContent = `${leftScore} : ${rightScore}`;
+}
+
+const keys = {};
+window.addEventListener('keydown', e => keys[e.code] = true);
+window.addEventListener('keyup', e => keys[e.code] = false);
+
+function animate() {
+  requestAnimationFrame(animate);
+  if (keys['ArrowUp']) paddleLeft.position.y += 0.3;
+  if (keys['ArrowDown']) paddleLeft.position.y -= 0.3;
+  paddleRight.position.y = THREE.MathUtils.clamp(ball.position.y, -5, 5);
+
+  ball.position.x += ballDirX;
+  ball.position.y += ballDirY;
+
+  if (ball.position.y > 5 || ball.position.y < -5) ballDirY = -ballDirY;
+  if (ball.position.x > 9.5 && Math.abs(ball.position.y - paddleRight.position.y) < 2) ballDirX = -ballDirX;
+  if (ball.position.x < -9.5 && Math.abs(ball.position.y - paddleLeft.position.y) < 2) ballDirX = -ballDirX;
+
+  if (ball.position.x > 11) { leftScore++; ball.position.set(0, 0, 0); ballDirX = -0.25; updateScore(); }
+  if (ball.position.x < -11) { rightScore++; ball.position.set(0, 0, 0); ballDirX = 0.25; updateScore(); }
+
+  renderer.render(scene, camera);
+}
+
+updateScore();
+animate();

--- a/index.html
+++ b/index.html
@@ -36,6 +36,10 @@ h1{color:#333;}
 <img src="https://dummyimage.com/600x400/000/fff&text=Flappy+Bird" alt="Flappy Bird">
 <h2>Flappy Bird</h2>
 </a>
+<a class="game" href="games/3d-pong/index.html">
+<img src="https://dummyimage.com/600x400/000/fff&text=3D+Pong" alt="3D Pong">
+<h2>3D Pong</h2>
+</a>
 </div>
 
 </body>


### PR DESCRIPTION
## Summary
- add new 3D Pong mini game built with Three.js
- update README with the new game
- show 3D Pong on the landing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a64a06d54833192f02a6f47ed88e6