### PR TITLE
Add tetris grid overlay

### DIFF
--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -10,7 +10,7 @@ canvas{background:#000;margin:20px auto;display:block;}
 </style>
 </head>
 <body>
-<h1>Tetris <span class="version">v1.0</span></h1>
+<h1>Tetris <span class="version">v1.1</span></h1>
 <canvas id="game" width="240" height="400"></canvas>
 <canvas id="next" width="80" height="80"></canvas>
 <p>Score: <span id="score">0</span> | Stage: <span id="stage">1</span></p>

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -213,9 +213,28 @@ function drawMatrix(matrix, offset, ctx = context) {
   });
 }
 
+function drawGrid() {
+  context.strokeStyle = 'rgba(255,255,255,0.1)';
+  context.lineWidth = 0.05;
+  for (let x = 0; x <= arena[0].length; x++) {
+    context.beginPath();
+    context.moveTo(x, 0);
+    context.lineTo(x, arena.length);
+    context.stroke();
+  }
+  for (let y = 0; y <= arena.length; y++) {
+    context.beginPath();
+    context.moveTo(0, y);
+    context.lineTo(arena[0].length, y);
+    context.stroke();
+  }
+}
+
 function draw() {
   context.fillStyle = '#000';
   context.fillRect(0, 0, canvas.width, canvas.height);
+
+  drawGrid();
 
   drawMatrix(arena, {x:0, y:0});
   drawMatrix(player.matrix, player.pos);

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ h1{color:#333;}
 <div class="games">
 <a class="game" href="games/tetris/index.html">
 <img src="https://dummyimage.com/600x400/000/fff&text=Tetris" alt="Tetris">
-<h2>Tetris <span class="version">v1.0</span></h2>
+<h2>Tetris <span class="version">v1.1</span></h2>
 </a>
 <a class="game" href="games/snake/index.html">
 <img src="https://dummyimage.com/600x400/000/fff&text=Snake" alt="Snake">


### PR DESCRIPTION
## Summary
- draw subtle grid lines on the Tetris board
- bump Tetris version to v1.1

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684a6b0421988331b839c8a9c0f64008