### PR TITLE
Add Tetris ghost piece and speed display

### DIFF
--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -10,10 +10,10 @@ canvas{background:#000;margin:20px auto;display:block;}
 </style>
 </head>
 <body>
-<h1>Tetris <span class="version">v1.1</span></h1>
+<h1>Tetris <span class="version">v1.2</span></h1>
 <canvas id="game" width="240" height="400"></canvas>
 <canvas id="next" width="80" height="80"></canvas>
-<p>Score: <span id="score">0</span> | Stage: <span id="stage">1</span></p>
+<p>Score: <span id="score">0</span> | Stage: <span id="stage">1</span> | Speed: <span id="speed">1000</span>ms</p>
 <p>Use arrow keys to move, rotate with up arrow, drop with space.</p>
 <script src="tetris.js"></script>
 </body>

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -175,6 +175,18 @@ function playerRotate(dir) {
   }
 }
 
+function getGhostPosition() {
+  const ghost = {
+    pos: { x: player.pos.x, y: player.pos.y },
+    matrix: player.matrix
+  };
+  while (!collide(arena, ghost)) {
+    ghost.pos.y++;
+  }
+  ghost.pos.y--;
+  return ghost.pos;
+}
+
 function arenaSweep() {
   let cleared = 0;
   outer: for (let y = arena.length - 1; y > 0; --y) {
@@ -200,11 +212,11 @@ function arenaSweep() {
   }
 }
 
-function drawMatrix(matrix, offset, ctx = context) {
+function drawMatrix(matrix, offset, ctx = context, colorOverride = null) {
   matrix.forEach((row, y) => {
     row.forEach((value, x) => {
       if (value !== 0) {
-        ctx.fillStyle = colors[value];
+        ctx.fillStyle = colorOverride || colors[value];
         ctx.fillRect(x + offset.x,
                      y + offset.y,
                      1, 1);
@@ -237,6 +249,8 @@ function draw() {
   drawGrid();
 
   drawMatrix(arena, {x:0, y:0});
+  const ghostPos = getGhostPosition();
+  drawMatrix(player.matrix, ghostPos, context, 'rgba(50,50,50,0.5)');
   drawMatrix(player.matrix, player.pos);
 }
 
@@ -276,6 +290,12 @@ function updateScore() {
 function updateStage() {
   const el = document.getElementById('stage');
   if (el) el.textContent = player.stage;
+  updateSpeed();
+}
+
+function updateSpeed() {
+  const el = document.getElementById('speed');
+  if (el) el.textContent = dropInterval;
 }
 
 const colors = [
@@ -306,4 +326,5 @@ document.addEventListener('keydown', event => {
 playerReset();
 updateScore();
 updateStage();
+updateSpeed();
 update();

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ h1{color:#333;}
 <div class="games">
 <a class="game" href="games/tetris/index.html">
 <img src="https://dummyimage.com/600x400/000/fff&text=Tetris" alt="Tetris">
-<h2>Tetris <span class="version">v1.1</span></h2>
+<h2>Tetris <span class="version">v1.2</span></h2>
 </a>
 <a class="game" href="games/snake/index.html">
 <img src="https://dummyimage.com/600x400/000/fff&text=Snake" alt="Snake">


### PR DESCRIPTION
## Summary
- show ghost piece to preview landing location
- display falling speed next to stage counter
- bump Tetris version to v1.2

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a83ca89948331bf32dacc96b58484