### PR TITLE
Update Tetris ghost piece visuals

### DIFF
--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -10,7 +10,7 @@ canvas{background:#000;margin:20px auto;display:block;}
 </style>
 </head>
 <body>
-<h1>Tetris <span class="version">v1.2</span></h1>
+<h1>Tetris <span class="version">v1.3</span></h1>
 <canvas id="game" width="240" height="400"></canvas>
 <canvas id="next" width="80" height="80"></canvas>
 <p>Score: <span id="score">0</span> | Stage: <span id="stage">1</span> | Speed: <span id="speed">1000</span>ms</p>

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -212,7 +212,9 @@ function arenaSweep() {
   }
 }
 
-function drawMatrix(matrix, offset, ctx = context, colorOverride = null) {
+function drawMatrix(matrix, offset, ctx = context, colorOverride = null, alpha = 1) {
+  ctx.save();
+  ctx.globalAlpha = alpha;
   matrix.forEach((row, y) => {
     row.forEach((value, x) => {
       if (value !== 0) {
@@ -223,6 +225,7 @@ function drawMatrix(matrix, offset, ctx = context, colorOverride = null) {
       }
     });
   });
+  ctx.restore();
 }
 
 function drawGrid() {
@@ -250,7 +253,7 @@ function draw() {
 
   drawMatrix(arena, {x:0, y:0});
   const ghostPos = getGhostPosition();
-  drawMatrix(player.matrix, ghostPos, context, 'rgba(50,50,50,0.5)');
+  drawMatrix(player.matrix, ghostPos, context, null, 0.5);
   drawMatrix(player.matrix, player.pos);
 }
 


### PR DESCRIPTION
## Summary
- show ghost pieces with the piece color at 50% transparency
- bump Tetris version to 1.3

## Testing
- `node --check games/tetris/tetris.js`

------
https://chatgpt.com/codex/tasks/task_e_684a86584c348331923820080e647290