### PR TITLE
Update Tetris version and gameplay

### DIFF
--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -10,7 +10,7 @@ canvas{background:#000;margin:20px auto;display:block;}
 </style>
 </head>
 <body>
-<h1>Tetris <span class="version">v1.4</span></h1>
+<h1>Tetris <span class="version">v1.5</span></h1>
 <canvas id="game" width="240" height="400"></canvas>
 <canvas id="next" width="80" height="80"></canvas>
 <p>Score: <span id="score">0</span> | Stage: <span id="stage">1</span> | Speed: <span id="speed">1000</span>ms</p>

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -205,7 +205,7 @@ function arenaSweep() {
     player.score += cleared * 10 * player.stage;
     if (player.lines >= player.stage * 10) {
       player.stage++;
-      dropInterval = Math.max(dropInterval * 0.9, 100);
+      dropInterval = Math.max(dropInterval * 0.8, 100);
       updateStage();
     }
     updateScore();
@@ -229,7 +229,7 @@ function drawMatrix(matrix, offset, ctx = context, colorOverride = null, alpha =
 }
 
 function drawGrid() {
-  context.strokeStyle = 'rgba(255,255,255,0.1)';
+  context.strokeStyle = 'rgba(255,255,255,0.3)';
   context.lineWidth = 0.05;
   for (let x = 0; x <= arena[0].length; x++) {
     context.beginPath();
@@ -253,7 +253,7 @@ function draw() {
 
   drawMatrix(arena, {x:0, y:0});
   const ghostPos = getGhostPosition();
-  drawMatrix(player.matrix, ghostPos, context, null, 0.5);
+  drawMatrix(player.matrix, ghostPos, context, null, 0.2);
   drawMatrix(player.matrix, player.pos);
 }
 

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ h1{color:#333;}
 <div class="games">
 <a class="game" href="games/tetris/index.html">
 <img src="https://dummyimage.com/600x400/000/fff&text=Tetris" alt="Tetris">
-<h2>Tetris <span class="version">v1.2</span></h2>
+<h2>Tetris <span class="version">v1.5</span></h2>
 </a>
 <a class="game" href="games/snake/index.html">
 <img src="https://dummyimage.com/600x400/000/fff&text=Snake" alt="Snake">


### PR DESCRIPTION
## Summary
- bump Tetris on landing page to `v1.5`
- bump game page version
- make the drop speed increase by 20% each stage
- darken the background grid and lighten ghost block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a8d7b176c8331a3adb5eff78c52aa