### PR TITLE
Disable caching for Tetris pages

### DIFF
--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
 <title>Tetris</title>
 <style>
 body{margin:0;text-align:center;background:#222;color:#fff;font-family:sans-serif;}
@@ -15,6 +18,6 @@ canvas{background:#000;margin:20px auto;display:block;}
 <canvas id="next" width="80" height="80"></canvas>
 <p>Score: <span id="score">0</span> | Stage: <span id="stage">1</span> | Speed: <span id="speed">1000</span>ms</p>
 <p>Use arrow keys to move, rotate with up arrow, drop with space.</p>
-<script src="tetris.js"></script>
+<script src="tetris.js?v=1.5"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
 
 <title>Game Hub</title>
 <style>


### PR DESCRIPTION
## Summary
- add no-cache meta headers to the main landing page
- add no-cache meta headers to the Tetris page
- append versioned query parameter to the Tetris script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a8f37c3d48331b1dfb66354186d36