### PR TITLE
Enhance Tetris with sound and high score

### DIFF
--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -21,6 +21,8 @@ canvas{background:#000;display:block;}
   <canvas id="next" width="80" height="80"></canvas>
 </div>
 <p>Use arrow keys to move, rotate with up arrow, drop with space.</p>
+<h2>Top 10 Records</h2>
+<ol id="records"></ol>
 <script src="tetris.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a small hall-of-fame list to the Tetris page
- play a short beep when a new stage begins
- save scores in localStorage and show a game over popup with your stats

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684aa057364c8331b8af8623f30ab878