### PR TITLE
Add sound effects for Tetris landing and clearing lines

### DIFF
--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -14,7 +14,7 @@ canvas{background:#000;display:block;}
 </style>
 </head>
 <body>
-<h1>Tetris <span class="version">v1.7</span></h1>
+<h1>Tetris <span class="version">v1.8</span></h1>
 <div id="info" class="info">Score: <span id="score">0</span> | Stage: <span id="stage">1</span> | Speed: <span id="speed">1000</span>ms</div>
 <div class="board">
   <canvas id="game" width="240" height="400"></canvas>

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -36,6 +36,40 @@ function playStageUpSound() {
   }
 }
 
+function playLandSound() {
+  try {
+    audioCtx = audioCtx || new (window.AudioContext || window.webkitAudioContext)();
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = 'square';
+    osc.frequency.value = 220;
+    gain.gain.setValueAtTime(0.1, audioCtx.currentTime);
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.1);
+  } catch (e) {
+    /* ignore */
+  }
+}
+
+function playClearSound() {
+  try {
+    audioCtx = audioCtx || new (window.AudioContext || window.webkitAudioContext)();
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = 'triangle';
+    osc.frequency.value = 660;
+    gain.gain.setValueAtTime(0.15, audioCtx.currentTime);
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.15);
+  } catch (e) {
+    /* ignore */
+  }
+}
+
 const STORAGE_KEY = 'tetrisHighScores';
 
 function getHighScores() {
@@ -157,6 +191,7 @@ function playerDrop() {
   if (collide(arena, player)) {
     player.pos.y--;
     merge(arena, player);
+    playLandSound();
     playerReset();
     arenaSweep();
   }
@@ -169,6 +204,7 @@ function playerHardDrop() {
   }
   player.pos.y--;
   merge(arena, player);
+  playLandSound();
   playerReset();
   arenaSweep();
   dropCounter = 0;
@@ -267,6 +303,7 @@ function arenaSweep() {
       updateStage();
       playStageUpSound();
     }
+    playClearSound();
     updateScore();
   }
 }


### PR DESCRIPTION
## Summary
- play sound when a piece lands on the board
- play sound when a line clears
- bump Tetris version to v1.8

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684aa2c09abc83318e01da3dbcb625af