### PR TITLE
Reduce Tetris audio volume and bump version

### DIFF
--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -14,7 +14,7 @@ canvas{background:#000;display:block;}
 </style>
 </head>
 <body>
-<h1>Tetris <span class="version">v0.2.1</span></h1>
+<h1>Tetris <span class="version">v0.2.2</span></h1>
 <div id="info" class="info">Score: <span id="score">0</span> | Stage: <span id="stage">1</span> | Speed: <span id="speed">1000</span>ms</div>
 <div class="board">
   <canvas id="game" width="240" height="400"></canvas>

--- a/games/tetris/tetris.js
+++ b/games/tetris/tetris.js
@@ -34,7 +34,7 @@ function playStartSound() {
       const gain = audioCtx.createGain();
       osc.type = 'square';
       osc.frequency.value = freq;
-      gain.gain.setValueAtTime(0.025, t);
+      gain.gain.setValueAtTime(0.001, t);
       osc.connect(gain);
       gain.connect(audioCtx.destination);
       osc.start(t);
@@ -57,7 +57,7 @@ function playEndSound() {
       const gain = audioCtx.createGain();
       osc.type = 'square';
       osc.frequency.value = freq;
-      gain.gain.setValueAtTime(0.03, t);
+      gain.gain.setValueAtTime(0.001, t);
       osc.connect(gain);
       gain.connect(audioCtx.destination);
       osc.start(t);
@@ -76,7 +76,7 @@ function playStageUpSound() {
     const gain = audioCtx.createGain();
     osc.type = 'square';
     osc.frequency.value = 880;
-    gain.gain.setValueAtTime(0.025, audioCtx.currentTime);
+    gain.gain.setValueAtTime(0.001, audioCtx.currentTime);
     osc.connect(gain);
     gain.connect(audioCtx.destination);
     osc.start();
@@ -96,7 +96,7 @@ function playLandSound() {
     osc2.type = 'square';
     osc1.frequency.value = 110;
     osc2.frequency.value = 165;
-    gain.gain.setValueAtTime(0.0125, audioCtx.currentTime);
+    gain.gain.setValueAtTime(0.001, audioCtx.currentTime);
     osc1.connect(gain);
     osc2.connect(gain);
     gain.connect(audioCtx.destination);

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ h1{color:#333;}
 <div class="games">
 <a class="game" href="games/tetris/index.html">
 <img src="https://dummyimage.com/600x400/000/fff&text=Tetris" alt="Tetris">
-<h2>Tetris <span class="version">v0.2.1</span></h2>
+<h2>Tetris <span class="version">v0.2.2</span></h2>
 </a>
 <a class="game" href="games/snake/index.html">
 <img src="https://dummyimage.com/600x400/000/fff&text=Snake" alt="Snake">


### PR DESCRIPTION
## Summary
- make Tetris sound nearly inaudible
- bump Tetris version to 0.2.2 on landing page and in the game

## Testing
- `npm test` *(fails: ENOENT: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684aee7109b08331b2bffd82cdf000c0